### PR TITLE
Add ruler.lineSlice

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,6 @@ var area = ruler.area([[
 Returns the bearing between two points in angles.
 3–4 times faster than `turf.bearing`.
 
-#### pointOnLine(line, p)
-
-Returns the closest point on the line from the given point.
-80–90 times faster than `turf.pointOnLine`.
-
 #### along(line, dist)
 
 Returns the point at a specified distance along the line.
@@ -81,6 +76,17 @@ Returns the point at a specified distance along the line.
 
 Returns a new point given distance and bearing from the starting point.
 6–7 times faster than `turf.destination`.
+
+#### pointOnLine(line, p)
+
+Returns an object of the form `{point, index}` where `point` is closest point on the line from the given point,
+and `index` is the start index of the segment with the closest point.
+70–75 times faster than `turf.pointOnLine`.
+
+#### lineSlice(start, stop, line)
+
+Returns a part of the given line between the start and the stop points (or their closest points on the line).
+50–60 times faster than `turf.lineSlice`.
 
 #### bufferPoint(p, buffer)
 

--- a/bench/bench-line-slice.js
+++ b/bench/bench-line-slice.js
@@ -1,0 +1,38 @@
+'use strict';
+
+var Benchmark = require('benchmark');
+
+var cheapRuler = require('../');
+var turf = require('turf');
+var lines = require('../test/fixtures/lines.json');
+
+var ruler = cheapRuler(32.8351);
+
+var suite = new Benchmark.Suite();
+
+var endpoints = lines.map(function (line) {
+    var dist = ruler.lineDistance(line);
+    return {
+        start: ruler.along(line, dist * 0.3),
+        stop: ruler.along(line, dist * 0.7)
+    };
+});
+
+suite
+.add('turf.lineSlice', function () {
+    for (var i = 0; i < lines.length; i++) {
+        turf.lineSlice(
+            turf.point(endpoints[i].start),
+            turf.point(endpoints[i].stop),
+            turf.linestring(lines[i]));
+    }
+})
+.add('ruler.lineSlice', function () {
+    for (var i = 0; i < lines.length; i++) {
+        ruler.lineSlice(endpoints[i].start, endpoints[i].stop, lines[i]);
+    }
+})
+.on('cycle', function (event) {
+    console.log(String(event.target));
+})
+.run();

--- a/index.js
+++ b/index.js
@@ -91,7 +91,7 @@ CheapRuler.prototype = {
 
     pointOnLine: function (line, p) {
         var minDist = Infinity;
-        var minX, minY, minI;
+        var minX, minY, minI, minT;
 
         for (var i = 0; i < line.length - 1; i++) {
 
@@ -123,31 +123,40 @@ CheapRuler.prototype = {
                 minX = x;
                 minY = y;
                 minI = i;
+                minT = t;
             }
         }
 
         return {
             point: [minX, minY],
-            index: minI
+            index: minI,
+            t: minT
         };
     },
 
     lineSlice: function (start, stop, line) {
         var p1 = this.pointOnLine(line, start);
         var p2 = this.pointOnLine(line, stop);
+
+        if (p1.index > p2.index || (p1.index === p2.index && p1.t > p2.t)) {
+            var tmp = p1;
+            p1 = p2;
+            p2 = tmp;
+        }
+
         var slice = [p1.point];
 
         var l = p1.index + 1;
         var r = p2.index;
 
-        if (line[l][0] !== slice[0][0] || line[l][1] !== slice[0][1])
+        if (!equals(line[l], slice[0]) && l <= r)
             slice.push(line[l]);
 
-        for (var i = l + 1; i <= p2.index; i++) {
+        for (var i = l + 1; i <= r; i++) {
             slice.push(line[i]);
         }
 
-        if (line[r][0] !== p2.point[0] || line[r][1] !== p2.point[1])
+        if (!equals(line[r], p2.point))
             slice.push(p2.point);
 
         return slice;
@@ -189,3 +198,7 @@ CheapRuler.prototype = {
         ];
     }
 };
+
+function equals(a, b) {
+    return a[0] === b[0] && a[1] === b[1];
+}

--- a/index.js
+++ b/index.js
@@ -132,6 +132,27 @@ CheapRuler.prototype = {
         };
     },
 
+    lineSlice: function (start, stop, line) {
+        var p1 = this.pointOnLine(line, start);
+        var p2 = this.pointOnLine(line, stop);
+        var slice = [p1.point];
+
+        var l = p1.index + 1;
+        var r = p2.index;
+
+        if (line[l][0] !== slice[0][0] || line[l][1] !== slice[0][1])
+            slice.push(line[l]);
+
+        for (var i = l + 1; i <= p2.index; i++) {
+            slice.push(line[i]);
+        }
+
+        if (line[r][0] !== p2.point[0] || line[r][1] !== p2.point[1])
+            slice.push(p2.point);
+
+        return slice;
+    },
+
     along: function (line, dist) {
         var sum = 0;
 

--- a/index.js
+++ b/index.js
@@ -91,7 +91,7 @@ CheapRuler.prototype = {
 
     pointOnLine: function (line, p) {
         var minDist = Infinity;
-        var minX, minY;
+        var minX, minY, minI;
 
         for (var i = 0; i < line.length - 1; i++) {
 
@@ -122,10 +122,14 @@ CheapRuler.prototype = {
                 minDist = sqDist;
                 minX = x;
                 minY = y;
+                minI = i;
             }
         }
 
-        return [minX, minY];
+        return {
+            point: [minX, minY],
+            index: minI
+        };
     },
 
     along: function (line, dist) {

--- a/test/test.js
+++ b/test/test.js
@@ -98,7 +98,7 @@ test('bufferPoint', function (t) {
 test('pointOnLine', function (t) {
     // not Turf comparison because pointOnLatter is bugged https://github.com/Turfjs/turf/issues/344
     var line = [[-77.031669, 38.878605], [-77.029609, 38.881946]];
-    var p = ruler.pointOnLine(line, [-77.034076, 38.882017]);
+    var p = ruler.pointOnLine(line, [-77.034076, 38.882017]).point;
     t.same(p, [-77.03051972665213, 38.88046894284234]);
     t.end();
 });

--- a/test/test.js
+++ b/test/test.js
@@ -48,6 +48,25 @@ test('along', function (t) {
     t.end();
 });
 
+test('lineSlice', function (t) {
+    for (var i = 0; i < lines.length; i++) {
+        if (i === 46) continue; // skip due to Turf bug https://github.com/Turfjs/turf/issues/351
+
+        var line = lines[i];
+        var dist = ruler.lineDistance(line);
+        var start = ruler.along(line, dist * 0.3);
+        var stop = ruler.along(line, dist * 0.7);
+
+        var expected = ruler.lineDistance(turf.lineSlice(
+            turf.point(start), turf.point(stop), turf.linestring(line)).geometry.coordinates);
+        var actual = ruler.lineDistance(ruler.lineSlice(start, stop, line));
+
+        assertErr(t, expected, actual, 0.001, 'lineSlice length');
+    }
+    t.pass('lineSlice length within 0.1%');
+    t.end();
+});
+
 test('area', function (t) {
     for (var i = 0; i < lines.length; i++) {
         if (lines[i].length < 3) continue;
@@ -96,7 +115,7 @@ test('bufferPoint', function (t) {
 });
 
 test('pointOnLine', function (t) {
-    // not Turf comparison because pointOnLatter is bugged https://github.com/Turfjs/turf/issues/344
+    // not Turf comparison because pointOnLine is bugged https://github.com/Turfjs/turf/issues/344
     var line = [[-77.031669, 38.878605], [-77.029609, 38.881946]];
     var p = ruler.pointOnLine(line, [-77.034076, 38.882017]).point;
     t.same(p, [-77.03051972665213, 38.88046894284234]);


### PR DESCRIPTION
Closes #9. Benchmark shows that it’s ~55 times faster than `turf.lineSlice`.

Also changes `pointOnLine` signature to return an object `{point, index, t}` rather than `point`.

- [x] Add tests
- [x] Update readme