### PR TITLE
Simplify `destination()` method

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,10 +117,10 @@ CheapRuler.prototype = {
      * //=point
      */
     destination: function (p, dist, bearing) {
-        var a = (90 - bearing) * Math.PI / 180;
+        var a = bearing * Math.PI / 180;
         return this.offset(p,
-            Math.cos(a) * dist,
-            Math.sin(a) * dist);
+            Math.sin(a) * dist,
+            Math.cos(a) * dist);
     },
 
     /**


### PR DESCRIPTION
Subtracting from 90 deg does not seem necessary if we swap the offset() arguments, which essentially boils down to a shift by 90 deg too.