### PR TITLE
README: Add cheap-ruler-rs to related projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,4 +212,5 @@ Errors for all other methods are similar.
 ## Related
 
 - [cheap-ruler-cpp](https://github.com/mapbox/cheap-ruler-cpp) – C++ port of this library
+- [cheap-ruler-rs](https://github.com/vipera/cheap-ruler-rs) – Rust port of this library
 - [flat-projection](https://github.com/Turbo87/flat-projection-rs) – Rust library based on the same concept


### PR DESCRIPTION
I've made a fully-featured Rust port of this library with the same interface. Perhaps it would be useful to list it under related projects.

https://github.com/vipera/cheap-ruler-rs