### PR TITLE
Use `readonly` in params

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,8 +76,8 @@ export default class CheapRuler {
     /**
      * Given two points of the form [longitude, latitude], returns the distance.
      *
-     * @param {[number, number]} a point [longitude, latitude]
-     * @param {[number, number]} b point [longitude, latitude]
+     * @param {readonly [number, number]} a point [longitude, latitude]
+     * @param {readonly [number, number]} b point [longitude, latitude]
      * @returns {number} distance
      * @example
      * const distance = ruler.distance([30.5, 50.5], [30.51, 50.49]);
@@ -92,8 +92,8 @@ export default class CheapRuler {
     /**
      * Returns the bearing between two points in angles.
      *
-     * @param {[number, number]} a point [longitude, latitude]
-     * @param {[number, number]} b point [longitude, latitude]
+     * @param {readonly [number, number]} a point [longitude, latitude]
+     * @param {readonly [number, number]} b point [longitude, latitude]
      * @returns {number} bearing
      * @example
      * const bearing = ruler.bearing([30.5, 50.5], [30.51, 50.49]);
@@ -108,7 +108,7 @@ export default class CheapRuler {
     /**
      * Returns a new point given distance and bearing from the starting point.
      *
-     * @param {[number, number]} p point [longitude, latitude]
+     * @param {readonly [number, number]} p point [longitude, latitude]
      * @param {number} dist distance
      * @param {number} bearing
      * @returns {[number, number]} point [longitude, latitude]
@@ -126,7 +126,7 @@ export default class CheapRuler {
     /**
      * Returns a new point given easting and northing offsets (in ruler units) from the starting point.
      *
-     * @param {[number, number]} p point [longitude, latitude]
+     * @param {readonly [number, number]} p point [longitude, latitude]
      * @param {number} dx easting
      * @param {number} dy northing
      * @returns {[number, number]} point [longitude, latitude]
@@ -144,7 +144,7 @@ export default class CheapRuler {
     /**
      * Given a line (an array of points), returns the total line distance.
      *
-     * @param {[number, number][]} points [longitude, latitude]
+     * @param {readonly [number, number][]} points [longitude, latitude]
      * @returns {number} total line distance
      * @example
      * const length = ruler.lineDistance([
@@ -164,7 +164,7 @@ export default class CheapRuler {
     /**
      * Given a polygon (an array of rings, where each ring is an array of points), returns the area.
      *
-     * @param {[number, number][][]} polygon
+     * @param {readonly [number, number][][]} polygon
      * @returns {number} area value in the specified units (square kilometers by default)
      * @example
      * const area = ruler.area([[
@@ -190,7 +190,7 @@ export default class CheapRuler {
     /**
      * Returns the point at a specified distance along the line.
      *
-     * @param {[number, number][]} line
+     * @param {readonly [number, number][]} line
      * @param {number} dist distance
      * @returns {[number, number]} point [longitude, latitude]
      * @example
@@ -216,9 +216,9 @@ export default class CheapRuler {
     /**
      * Returns the distance from a point `p` to a line segment `a` to `b`.
      *
-     * @param {[number, number]} p point [longitude, latitude]
-     * @param {[number, number]} a segment point 1 [longitude, latitude]
-     * @param {[number, number]} b segment point 2 [longitude, latitude]
+     * @param {readonly [number, number]} p point [longitude, latitude]
+     * @param {readonly [number, number]} a segment point 1 [longitude, latitude]
+     * @param {readonly [number, number]} b segment point 2 [longitude, latitude]
      * @returns {number} distance
      * @example
      * const distance = ruler.pointToSegmentDistance([-67.04, 50.5], [-67.05, 50.57], [-67.03, 50.54]);
@@ -253,8 +253,8 @@ export default class CheapRuler {
      * from the given point, index is the start index of the segment with the closest point,
      * and t is a parameter from 0 to 1 that indicates where the closest point is on that segment.
      *
-     * @param {[number, number][]} line
-     * @param {[number, number]} p point [longitude, latitude]
+     * @param {readonly [number, number][]} line
+     * @param {readonly [number, number]} p point [longitude, latitude]
      * @returns {{point: [number, number], index: number, t: number}} {point, index, t}
      * @example
      * const point = ruler.pointOnLine(line, [-67.04, 50.5]).point;
@@ -311,9 +311,9 @@ export default class CheapRuler {
     /**
      * Returns a part of the given line between the start and the stop points (or their closest points on the line).
      *
-     * @param {[number, number]} start point [longitude, latitude]
-     * @param {[number, number]} stop point [longitude, latitude]
-     * @param {[number, number][]} line
+     * @param {readonly [number, number]} start point [longitude, latitude]
+     * @param {readonly [number, number]} stop point [longitude, latitude]
+     * @param {readonly [number, number][]} line
      * @returns {[number, number][]} line part of a line
      * @example
      * const line2 = ruler.lineSlice([-67.04, 50.5], [-67.05, 50.56], line1);
@@ -353,7 +353,7 @@ export default class CheapRuler {
      *
      * @param {number} start start distance
      * @param {number} stop stop distance
-     * @param {[number, number][]} line
+     * @param {readonly [number, number][]} line
      * @returns {[number, number][]} part of a line
      * @example
      * const line2 = ruler.lineSliceAlong(10, 20, line1);
@@ -388,7 +388,7 @@ export default class CheapRuler {
     /**
      * Given a point, returns a bounding box object ([w, s, e, n]) created from the given point buffered by a given distance.
      *
-     * @param {[number, number]} p point [longitude, latitude]
+     * @param {readonly [number, number]} p point [longitude, latitude]
      * @param {number} buffer
      * @returns {[number, number, number, number]} bbox ([w, s, e, n])
      * @example
@@ -409,7 +409,7 @@ export default class CheapRuler {
     /**
      * Given a bounding box, returns the box buffered by a given distance.
      *
-     * @param {[number, number, number, number]} bbox ([w, s, e, n])
+     * @param {readonly [number, number, number, number]} bbox ([w, s, e, n])
      * @param {number} buffer
      * @returns {[number, number, number, number]} bbox ([w, s, e, n])
      * @example
@@ -430,8 +430,8 @@ export default class CheapRuler {
     /**
      * Returns true if the given point is inside in the given bounding box, otherwise false.
      *
-     * @param {[number, number]} p point [longitude, latitude]
-     * @param {[number, number, number, number]} bbox ([w, s, e, n])
+     * @param {readonly [number, number]} p point [longitude, latitude]
+     * @param {readonly [number, number, number, number]} bbox ([w, s, e, n])
      * @returns {boolean}
      * @example
      * const inside = ruler.insideBBox([30.5, 50.5], [30, 50, 31, 51]);
@@ -446,16 +446,16 @@ export default class CheapRuler {
 }
 
 /**
- * @param {[number, number]} a
- * @param {[number, number]} b
+ * @param {readonly [number, number]} a
+ * @param {readonly [number, number]} b
  */
 function equals(a, b) {
     return a[0] === b[0] && a[1] === b[1];
 }
 
 /**
- * @param {[number, number]} a
- * @param {[number, number]} b
+ * @param {readonly [number, number]} a
+ * @param {readonly [number, number]} b
  * @param {number} t
  * @returns {[number, number]}
  */


### PR DESCRIPTION
Since array arguments are not mutated, we can add `readonly` to array parameter types.

This way we can directly pass readonly arrays to `CheapRuler` methods:

```ts
const ruler = new CheapRuler(42, 'miles');

// Readonly arrays
const a = [1, 2] as const;
const b = [3, 4] as const;

ruler.distance(a, b); // Ok!
```

Otherwise, we have to needlessly copy the arrays to avoid TypeScript errors:
```ts
// @ts-expect-error - Argument of type 'readonly [1, 2]' is not assignable to parameter of type '[number, number]'. The type 'readonly [1, 2]' is 'readonly' and cannot be assigned to the mutable type '[number, number]'.
ruler.distance(a, b);

// or copy the arrays to avoid errors:
ruler.distance([...a], [...b]);
```