### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -1,5 +1,7 @@
 name: Node
 on: [push, pull_request]
+permissions:
+  contents: read
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/mapbox/cheap-ruler/security/code-scanning/1](https://github.com/mapbox/cheap-ruler/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/node.yml` at the workflow root so it applies to all jobs unless overridden. For this workflow, `contents: read` is the minimal and appropriate permission based on the shown steps (`actions/checkout`, dependency install, test, build). This preserves existing behavior while documenting and enforcing least privilege.

Make one edit near the top of the file, directly under `on:` (or under `name:` before `on:`), adding:

```yml
permissions:
  contents: read
```

No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
