### PR TITLE
Fix area() for polygons with oppositely-wound holes

### DIFF
--- a/index.js
+++ b/index.js
@@ -189,9 +189,11 @@ export default class CheapRuler {
         for (let i = 0; i < polygon.length; i++) {
             const ring = polygon[i];
 
+            let ringSum = 0;
             for (let j = 0, len = ring.length, k = len - 1; j < len; k = j++) {
-                sum += wrap(ring[j][0] - ring[k][0]) * (ring[j][1] + ring[k][1]) * (i ? -1 : 1);
+                ringSum += wrap(ring[j][0] - ring[k][0]) * (ring[j][1] + ring[k][1]);
             }
+            sum += Math.abs(ringSum) * (i ? -1 : 1);
         }
 
         return (Math.abs(sum) / 2) * this.kx * this.ky;

--- a/test/test.js
+++ b/test/test.js
@@ -99,6 +99,17 @@ test('area', () => {
     // area within 0.3%
 });
 
+test('area with a hole', () => {
+    const holeRuler = new CheapRuler(50.5);
+    const outer = [[-67.031, 50.458], [-66.929, 50.458], [-66.929, 50.534], [-67.031, 50.534], [-67.031, 50.458]];
+    const hole = [[-67.0, 50.48], [-67.0, 50.51], [-66.96, 50.51], [-66.96, 50.48], [-67.0, 50.48]];
+    const poly = [outer, hole];
+    const expected = turf.area(turf.polygon(poly)) / 1e6;
+    const actual = holeRuler.area(poly);
+    assertErr(expected, actual, 0.005, 'area with a hole');
+    // area with a hole within 0.5%
+});
+
 test('along', () => {
     for (let i = 0; i < lines.length; i++) {
         const line = turf.lineString(lines[i]);


### PR DESCRIPTION
`area()` returns an inflated result for a polygon with a hole when the hole is wound opposite to the exterior ring, which is the GeoJSON standard (RFC 7946: exterior counter-clockwise, holes clockwise). The hole is added to the exterior area instead of being subtracted.

For a roughly 50 km2 polygon with a hole, `area()` returns about 92.95 km2 instead of the correct 51.53 km2 (about an 80 percent over-estimate), with no error.

## Cause

`area()` accumulates the shoelace sum of every ring into a single `sum`, applying only a position-based sign (`i ? -1 : 1`) and taking `Math.abs` at the end. A ring's raw shoelace sum is positive or negative depending on its winding, so this only works when all rings share the exterior ring's winding. When a hole has the opposite winding, its sum already carries the opposite sign, and the position factor makes it add rather than subtract; the final `Math.abs` cannot recover the two magnitudes once combined. `@turf/turf` `area` (the reference used by this library's own tests) subtracts holes by position and is winding-agnostic.

## Fix

Take the absolute value of each ring's shoelace sum before applying the position sign. This makes the result winding-agnostic and correct for both the GeoJSON standard and same-winding input; single-ring polygons are unchanged.

## Testing

Added an `area with a hole` test in the repo's turf-comparison style with an exterior CCW ring and a CW hole. It is off by about 27 percent on the current code and within 0.5 percent of turf with the fix. The existing single-ring `area` test and the rest of the suite stay green (26 tests).
