### PR TITLE
fix: clamp negative start distance in lineSliceAlong

### DIFF
--- a/index.js
+++ b/index.js
@@ -389,6 +389,8 @@ export default class CheapRuler {
         let sum = 0;
         const slice = [];
 
+        if (start < 0) start = 0;
+
         let p0 = line[0];
         let ax = p0[0];
         let ay = p0[1];

--- a/test/test.js
+++ b/test/test.js
@@ -203,6 +203,13 @@ test('lineSliceAlong', () => {
     // lineSliceAlong length within 1e-5
 });
 
+test('lineSliceAlong with negative start', () => {
+    const line = lines[0];
+    const dist = ruler.lineDistance(line);
+    const slice = ruler.lineSliceAlong(-1, dist * 0.5, line);
+    assert.deepEqual(slice[0], line[0], 'starts at the beginning of the line');
+});
+
 test('lineSlice reverse', () => {
     const line = lines[0];
     const dist = ruler.lineDistance(line);


### PR DESCRIPTION
`lineSliceAlong` interpolated the start point with a negative parameter when `start` was below zero, so the first vertex of the returned slice landed before the beginning of the line instead of on it. `along` already guards `dist <= 0` by returning the first point, and `lineSliceAlong` already stops at the last vertex when `stop` runs past the line length, so the start end was the only one left unclamped. This clamps `start` to 0 so the slice begins at the start of the line. Adds a test.
